### PR TITLE
Add GitHub actions, based on those in mozilla-l10n/www-l10n

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla-l10n/l10n-springfield

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mozilla-l10n/l10n-springfield
+* @mozilla-l10n/l10n-bedrock

--- a/.github/linter_config.yml
+++ b/.github/linter_config.yml
@@ -25,14 +25,6 @@ CO01:
     exclusions:
         files: []
         messages:
-            # 404-locale.ftl
-            - not-found-locale-title
-            # firefox/browsers.ftl
-            - firefox-browsers-already-have-an-account-sign
             # firefox/developer.ftl
             - firefox-developer-monitor-network-requests
             - firefox-developer-learn-more-about-newtork-monitor
-            # firefox/features/translate.ftl
-            - features-translate-for-everyone
-            # newsletters/newsletters.ftl
-            - newsletters-former-university-program

--- a/.github/linter_config.yml
+++ b/.github/linter_config.yml
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# See https://github.com/mozilla-l10n/moz-fluent-linter/blob/main/src/fluent_linter/config.yml
+# for details
+
+---
+ID01:
+    enabled: true
+    exclusions:
+        messages: []
+        files: []
+ID02:
+    enabled: true
+    min_length: 6
+    exclusions:
+        messages: []
+        files: []
+CO01:
+    enabled: true
+    brands:
+        - Firefox
+        - Mozilla
+    exclusions:
+        files: []
+        messages:
+            # 404-locale.ftl
+            - not-found-locale-title
+            # firefox/browsers.ftl
+            - firefox-browsers-already-have-an-account-sign
+            # firefox/developer.ftl
+            - firefox-developer-monitor-network-requests
+            - firefox-developer-learn-more-about-newtork-monitor
+            # firefox/features/translate.ftl
+            - features-translate-for-everyone
+            # newsletters/newsletters.ftl
+            - newsletters-former-university-program

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,0 +1,2 @@
+moz-fluent-linter~=0.4.7
+moz-l10n~=0.6.1

--- a/.github/scripts/clean_firefox_com.py
+++ b/.github/scripts/clean_firefox_com.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import os
+from pathlib import Path
+
+from moz.l10n.paths import L10nConfigPaths
+
+
+class FilesExtraction:
+    def __init__(self, repo_path):
+        """Initialize object."""
+        self.repo_path = repo_path
+        self.ref_files = []
+        self.l10n_files = []
+        self.local_files = []
+        self.unlisted_files = []
+        self.obsolete_files = []
+
+        self.extractFilesTOML()
+        self.extractFilesLocal()
+        self.findObsoleteFiles()
+
+    def findObsoleteFiles(self):
+        """
+        Find obsolete files
+        """
+
+        # Check for files that should not exist based on the TOML configurations.
+        # Ignore files in the en-US folder.
+        all_toml_files = self.ref_files + self.l10n_files
+        self.unlisted_files = [
+            f
+            for f in self.local_files
+            if f not in all_toml_files and not f.startswith("en-US/")
+        ]
+        if self.unlisted_files:
+            self.unlisted_files.sort()
+            print(
+                f"\n----\nThere are files not listed in TOML files ({len(self.unlisted_files)})"
+            )
+            print("\n".join(self.unlisted_files))
+
+        # Check for files that don't exist in the reference folder
+        ref_folder = "en"
+        ref_local_files = [
+            os.path.sep.join(f.split("/")[1:])
+            for f in self.local_files
+            if f.startswith(f"{ref_folder}/")
+        ]
+
+        for f in self.local_files:
+            if f.startswith((f"{ref_folder}/", "en-US/")):
+                continue
+            if os.path.sep.join(f.split("/")[1:]) not in ref_local_files:
+                self.obsolete_files.append(f)
+
+        if self.obsolete_files:
+            self.obsolete_files.sort()
+            print(
+                f"\n----\nThere are files not present in the {ref_folder} folder ({len(self.obsolete_files)})"
+            )
+            print("\n".join(self.obsolete_files))
+
+    def deleteObsoleteFiles(self):
+        """
+        Delete obsolete files
+        """
+
+        for f in self.obsolete_files:
+            os.remove(os.path.join(self.repo_path, f))
+
+    def deleteAllFiles(self):
+        """
+        Delete obsolete files and files not listed in TOML configurations
+        """
+
+        for f in self.unlisted_files + self.obsolete_files:
+            os.remove(os.path.join(self.repo_path, f))
+
+    def extractFilesLocal(self):
+        """
+        Extract the list of FTL files in the repository.
+        """
+
+        src_path = Path(self.repo_path)
+        self.local_files = [str(p) for p in src_path.rglob("*/*.ftl")]
+
+    def extractFilesTOML(self):
+        """
+        Extract the list of files supported by community (l10n-pontoon.toml)
+        and vendor (l10n-vendor.toml).
+        """
+
+        # Extract community files
+        toml_file = os.path.join(self.repo_path, "l10n-pontoon.toml")
+        project_config_paths = L10nConfigPaths(toml_file)
+        basedir = project_config_paths.base
+
+        # Extract the list of files for the reference locale
+        print("\n----\nCommunity Configuration")
+        print("Extracting files for reference locale...")
+        self.ref_files = [
+            os.path.relpath(ref_path, basedir)
+            for ref_path in project_config_paths.ref_paths
+        ]
+
+        # Extract other locales
+        locales = list(project_config_paths.all_locales)
+        locales.sort()
+        if not locales:
+            print("No locales defined in the project configuration...")
+        else:
+            print(f"Extracting files for other locales ({len(locales)})...")
+            tgt_paths = [tgt_path for _, tgt_path in project_config_paths.all()]
+            for locale in locales:
+                self.l10n_files.extend(
+                    os.path.relpath(path, basedir)
+                    for tgt_path in tgt_paths
+                    if os.path.exists(
+                        path := project_config_paths.format_target_path(
+                            tgt_path, locale
+                        )
+                    )
+                )
+
+        # Extract vendor files
+        basedir = os.path.dirname(self.repo_path)
+        toml_file = os.path.join(basedir, "l10n-vendor.toml")
+        project_config_paths = L10nConfigPaths(toml_file)
+
+        # Extract the list of files for the reference locale
+        print("\n----\nVendor Configuration")
+        print("Extracting files for reference locale...")
+        tmp_ref_files = []
+        tmp_ref_files = [
+            os.path.relpath(ref_path, basedir)
+            for ref_path in project_config_paths.ref_paths
+        ]
+        # Add to existing array of files, remove duplicates and sort
+        self.ref_files.extend(tmp_ref_files)
+        self.ref_files = list(set(self.ref_files))
+        self.ref_files.sort()
+
+        # Extract other locales
+        locales = list(project_config_paths.all_locales)
+        locales.sort()
+        if not locales:
+            print("No locales defined in the project configuration.")
+        else:
+            print(f"Extracting files for other locales ({len(locales)}).")
+            tmp_l10n_files = []
+            for locale in locales:
+                tmp_l10n_files.extend(
+                    [
+                        os.path.relpath(tgt_path.format(locale=locale), basedir)
+                        for (
+                            ref_path,
+                            tgt_path,
+                        ), locales in project_config_paths.all().items()
+                        if locale in locales
+                    ]
+                )
+            # Add to existing array of files, remove duplicates and sort
+            self.l10n_files.extend(tmp_l10n_files)
+            self.l10n_files = list(set(self.l10n_files))
+            self.l10n_files.sort()
+
+        print(f"\n\nExtracted {len(self.ref_files)} vendor files.")
+        print(f"Extracted {len(self.l10n_files)} l10n files.")
+
+
+def main():
+    # Read command line input parameters
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path",
+        required=True,
+        dest="repo_path",
+        help="Path to the www-firefox-l10n local clone",
+    )
+    parser.add_argument(
+        "--delete",
+        help="Delete obsolete files",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--deleteall",
+        help="Delete obsolete and unlisted (not in TOML) files",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    extracted_files = FilesExtraction(args.repo_path)
+    if args.delete:
+        extracted_files.deleteObsoleteFiles()
+    if args.deleteall:
+        extracted_files.deleteAllFiles()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/notify_springfield_of_updates.yaml
+++ b/.github/workflows/notify_springfield_of_updates.yaml
@@ -1,11 +1,11 @@
 # Notify Springfield that l10n files have updated, by pinging Springfield's Fluent-files
 # update pipeline at mozmeao/springfield-fluent-update
 
-name: Ping mozmeao/springfield-fluent-update when master changes
+name: Ping mozmeao/springfield-fluent-update when main changes
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch: # For manual runs, if needed
 
 concurrency:

--- a/.github/workflows/notify_springfield_of_updates.yaml
+++ b/.github/workflows/notify_springfield_of_updates.yaml
@@ -1,0 +1,28 @@
+# Notify Springfield that l10n files have updated, by pinging Springfield's Fluent-files
+# update pipeline at mozmeao/springfield-fluent-update
+
+name: Ping mozmeao/springfield-fluent-update when master changes
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: # For manual runs, if needed
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  notify-of-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger webhook
+        shell: bash
+        run: >
+          curl -X POST
+          https://api.github.com/repos/mozmeao/springfield-fluent-update/actions/workflows/run-fluent-updates.yml/dispatches
+          --header "Accept: application/vnd.github+json"
+          --header "Authorization: Bearer ${{ secrets.SPRINGFIELD_FLUENT_UPDATE_PAT }}"
+          --header "Content-Type: application/json"
+          -d '{"ref":"main"}'
+        # 'main' as the ref above refers to the branch on the www-fluent-update repo

--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -1,0 +1,32 @@
+name: Lint Reference Files
+on:
+  push:
+    paths:
+      - 'en/**.ftl'
+      - '.github/workflows/reference_linter.yaml'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'en/**.ftl'
+      - '.github/workflows/reference_linter.yaml'
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install Python dependencies
+        run: |
+          pip install -r .github/requirements.txt
+      - name: Lint reference
+        run: |
+          moz-fluent-lint ./en --config .github/linter_config.yml

--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -5,13 +5,13 @@ on:
       - 'en/**.ftl'
       - '.github/workflows/reference_linter.yaml'
     branches:
-      - master
+      - main
   pull_request:
     paths:
       - 'en/**.ftl'
       - '.github/workflows/reference_linter.yaml'
     branches:
-      - master
+      - main
   workflow_dispatch:
 jobs:
   linter:


### PR DESCRIPTION
This changeset ports of the GitHub actions from mozilla-l10n/www-l10n to this repo, adjusting for Springfield / www.firefox.com accordingly.

I'm not sure what else needs to happen to hook into Pontoon, but if there's anything you need from me, let me know.

Also please note that the I've bootstrapped the content of these repos with pre-existing FTL files from Bedrock (because Springfield was extracted from Bedrock). There have been a few (4) files renamed in Springfield, and those renames/moves have been reflected in this repo and in https://github.com/mozmeao/www-firefox-l10n as well